### PR TITLE
Fix memmove with zero size causing segmentation fault.

### DIFF
--- a/dwarf/cursor.cc
+++ b/dwarf/cursor.cc
@@ -92,7 +92,8 @@ cursor::string(std::string &out)
         size_t size;
         const char *p = this->cstr(&size);
         out.resize(size);
-        memmove(&out.front(), p, size);
+        if (size)
+                memmove(&out.front(), p, size);
 }
 
 const char *


### PR DESCRIPTION
This is just a quick unit test segfault fix, could be wrong but really lets the tests run.